### PR TITLE
🎨 Palette: Add precise timestamps to session list

### DIFF
--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { CardSpotlight } from "@/components/ui/card-spotlight";
-import { formatDistanceToNow, isValid, parseISO, isToday } from "date-fns";
+import { formatDistanceToNow, isValid, parseISO, isToday, format } from "date-fns";
 import { getArchivedSessions } from "@/lib/archive";
 
 function truncateText(text: string, maxLength: number) {
@@ -243,9 +243,25 @@ export function SessionList({
                         </Badge>
                       )}
                     </div>
-                    <div className="text-[9px] text-white/40 leading-tight font-mono tracking-wide">
-                      {formatDate(session.createdAt)}
-                    </div>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="text-[9px] text-white/40 leading-tight font-mono tracking-wide cursor-help">
+                          {formatDate(session.createdAt)}
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent
+                        side="bottom"
+                        align="start"
+                        className="bg-zinc-900 border-white/10 text-white text-[10px] z-[60]"
+                      >
+                        {session.createdAt &&
+                        isValid(parseISO(session.createdAt)) ? (
+                          <p>{format(parseISO(session.createdAt), "PPpp")}</p>
+                        ) : (
+                          <p>Unknown date</p>
+                        )}
+                      </TooltipContent>
+                    </Tooltip>
                   </div>
                 </div>
               </CardSpotlight>


### PR DESCRIPTION
Implemented the "Progressive Disclosure for Metadata" pattern by adding tooltips to the relative timestamps in the session list. Now, hovering over "5 minutes ago" reveals the exact date and time (e.g., "Jan 31, 2026, 5:28:31 PM").

This micro-UX improvement:
- Keeps the UI clean and scannable with relative times.
- Provides precision on demand for users who need exact timestamps.
- Improves accessibility by adding `cursor-help` and standard tooltip interactions.

Verified with `pnpm test` and a custom Playwright script.

---
*PR created automatically by Jules for task [4906395623590021337](https://jules.google.com/task/4906395623590021337) started by @sbhavani*