### PR TITLE
🎨 Palette: Add clear button to session search

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-12-21 - Instant Search Feedback
+
+**Learning:** Search inputs without a clear mechanism force users to manually delete text, creating unnecessary friction. A simple "X" button provides immediate reset capability and visual confirmation that a filter is active.
+**Action:** Always include a clear button for text-based filters and ensure it is keyboard accessible.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -184,14 +184,24 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-muted-foreground hover:text-white focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-purple-500 rounded-sm transition-colors"
+                aria-label="Clear search"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">


### PR DESCRIPTION
*   💡 What: Added a clear ('X') button to the session list search input that appears when text is entered.
*   🎯 Why: To allow users to quickly reset their search filter without manually deleting text.
*   ♿ Accessibility: Added `aria-label="Clear search"`, keyboard focus support, and `pointer-events-none` to the decorative search icon.
*   Also updated `.jules/palette.md` with learnings.

---
*PR created automatically by Jules for task [8794761838429612524](https://jules.google.com/task/8794761838429612524) started by @sbhavani*