### PR TITLE
🎨 Palette: Improve search input UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-01-22 - Search Input Usability
+
+**Learning:** Search inputs without a clear mechanism to reset the query force users to manually delete text, which is tedious, especially on mobile devices. Furthermore, decorative icons inside input fields (like a search icon) can interfere with text selection or clicking if they lack `pointer-events-none`.
+**Action:** Always include a clear button ("X") that appears when a search query is active. Ensure decorative icons over inputs have `pointer-events-none`.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -153,20 +153,6 @@ export function SessionList({
 
 
 
-  if (visibleSessions.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-6">
-        <p className="text-xs text-muted-foreground text-center leading-relaxed">
-          {searchQuery
-            ? "No sessions match your search."
-            : sessions.length === 0
-              ? "No sessions yet. Create one to get started!"
-              : "All sessions are archived."}
-        </p>
-      </div>
-    );
-  }
-
   const sessionLimit = 100;
   // Calculate usage based on sessions created today, regardless of search/archive status
   const dailySessionCount = sessions.filter((session) => {
@@ -184,17 +170,38 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50 pr-7"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-white"
+                aria-label="Clear search"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">
+          {visibleSessions.length === 0 ? (
+            <div className="flex items-center justify-center p-6 h-full">
+              <p className="text-xs text-muted-foreground text-center leading-relaxed">
+                {searchQuery
+                  ? "No sessions match your search."
+                  : sessions.length === 0
+                    ? "No sessions yet. Create one to get started!"
+                    : "All sessions are archived."}
+              </p>
+            </div>
+          ) : (
           <div className="p-2 space-y-1">
             {visibleSessions.map((session) => (
               <CardSpotlight
@@ -251,6 +258,7 @@ export function SessionList({
               </CardSpotlight>
             ))}
           </div>
+          )}
         </ScrollArea>
 
         {/* Session Limit Indicator */}


### PR DESCRIPTION
💡 **What**: Added a clear button to the search input in the session list, and prevented the search icon from intercepting clicks. Also fixed the layout so that the search bar doesn't disappear when there are no matching results.
🎯 **Why**: Users need a quick way to clear their search query without manually deleting text. Decorative icons shouldn't block interaction. When a search yields no results, the user should still be able to see and clear the search bar.
📸 **Before/After**: (Verified via Playwright screenshots).
♿ **Accessibility**: Added `aria-label="Clear search"` to the new button. Set `type="button"` to prevent accidental form submissions. Added `pointer-events-none` to the decorative search icon.

---
*PR created automatically by Jules for task [8203383421761874534](https://jules.google.com/task/8203383421761874534) started by @sbhavani*