### PR TITLE
🎨 Palette: Add accessible clear button to search input and fix empty states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2026-03-14 - Accessible Search Input Interactions
+
+**Learning:** Input fields meant for searching or filtering can be tedious to empty manually. Providing a clear ('X') button when text is present reduces friction significantly. Additionally, decorative icons placed over inputs must be strictly non-interactive to avoid absorbing user clicks.
+**Action:** Always implement a clear button for search inputs, ensuring decorative icons use `pointer-events-none` and interactive buttons have proper `aria-label` attributes for screen readers.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -153,20 +153,6 @@ export function SessionList({
 
 
 
-  if (visibleSessions.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-6">
-        <p className="text-xs text-muted-foreground text-center leading-relaxed">
-          {searchQuery
-            ? "No sessions match your search."
-            : sessions.length === 0
-              ? "No sessions yet. Create one to get started!"
-              : "All sessions are archived."}
-        </p>
-      </div>
-    );
-  }
-
   const sessionLimit = 100;
   // Calculate usage based on sessions created today, regardless of search/archive status
   const dailySessionCount = sessions.filter((session) => {
@@ -184,72 +170,94 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 h-4 w-4 rounded-sm flex items-center justify-center text-muted-foreground hover:text-white hover:bg-white/10 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50"
+              >
+                <X className="h-2.5 w-2.5" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-2 space-y-1">
-            {visibleSessions.map((session) => (
-              <CardSpotlight
-                key={session.id}
-                radius={250}
-                color={selectedSessionId === session.id ? "#a855f7" : "#404040"}
-                className={`relative ${
-                  selectedSessionId === session.id ? "border-purple-500/30" : ""
-                }`}
-              >
-                <div
-                  role="button"
-                  tabIndex={0}
-                  aria-label={`Select session ${session.title || "Untitled"}`}
-                  className="w-full flex items-start gap-2.5 px-3 py-2.5 text-left relative z-10 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-purple-500/50"
-                  onClick={() => onSelectSession(session)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      onSelectSession(session);
-                    }
-                  }}
+            {visibleSessions.length === 0 ? (
+              <div className="flex items-center justify-center p-6">
+                <p className="text-xs text-muted-foreground text-center leading-relaxed">
+                  {searchQuery
+                    ? "No sessions match your search."
+                    : sessions.length === 0
+                      ? "No sessions yet. Create one to get started!"
+                      : "All sessions are archived."}
+                </p>
+              </div>
+            ) : (
+              visibleSessions.map((session) => (
+                <CardSpotlight
+                  key={session.id}
+                  radius={250}
+                  color={selectedSessionId === session.id ? "#a855f7" : "#404040"}
+                  className={`relative ${
+                    selectedSessionId === session.id ? "border-purple-500/30" : ""
+                  }`}
                 >
                   <div
-                    className={`flex-shrink-0 mt-1 w-2 h-2 rounded-full ${getStatusColor(session.status)}`}
-                  />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 mb-0.5 w-full min-w-0">
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="text-[10px] font-bold leading-tight text-white uppercase tracking-wide flex-1 min-w-0 block overflow-hidden text-ellipsis whitespace-nowrap">
-                            {truncateText(session.title || "Untitled", 30)}
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent
-                          side="bottom"
-                          align="start"
-                          className="bg-zinc-900 border-white/10 text-white text-[10px] max-w-[200px] break-words z-[60]"
-                        >
-                          <p>{session.title || "Untitled"}</p>
-                        </TooltipContent>
-                      </Tooltip>
-                      {session.sourceId && (
-                        <Badge className="shrink-0 text-[9px] px-1.5 py-0 h-4 font-mono bg-white/10 text-white/70 hover:bg-white/20 border-0 rounded-sm uppercase tracking-wider">
-                          {getRepoShortName(session.sourceId)}
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="text-[9px] text-white/40 leading-tight font-mono tracking-wide">
-                      {formatDate(session.createdAt)}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Select session ${session.title || "Untitled"}`}
+                    className="w-full flex items-start gap-2.5 px-3 py-2.5 text-left relative z-10 cursor-pointer outline-none focus-visible:ring-1 focus-visible:ring-purple-500/50"
+                    onClick={() => onSelectSession(session)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        onSelectSession(session);
+                      }
+                    }}
+                  >
+                    <div
+                      className={`flex-shrink-0 mt-1 w-2 h-2 rounded-full ${getStatusColor(session.status)}`}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-0.5 w-full min-w-0">
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="text-[10px] font-bold leading-tight text-white uppercase tracking-wide flex-1 min-w-0 block overflow-hidden text-ellipsis whitespace-nowrap">
+                              {truncateText(session.title || "Untitled", 30)}
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent
+                            side="bottom"
+                            align="start"
+                            className="bg-zinc-900 border-white/10 text-white text-[10px] max-w-[200px] break-words z-[60]"
+                          >
+                            <p>{session.title || "Untitled"}</p>
+                          </TooltipContent>
+                        </Tooltip>
+                        {session.sourceId && (
+                          <Badge className="shrink-0 text-[9px] px-1.5 py-0 h-4 font-mono bg-white/10 text-white/70 hover:bg-white/20 border-0 rounded-sm uppercase tracking-wider">
+                            {getRepoShortName(session.sourceId)}
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="text-[9px] text-white/40 leading-tight font-mono tracking-wide">
+                        {formatDate(session.createdAt)}
+                      </div>
                     </div>
                   </div>
-                </div>
-              </CardSpotlight>
-            ))}
+                </CardSpotlight>
+              ))
+            )}
           </div>
         </ScrollArea>
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,20 @@
+1. **Understand the Goal**: Based on the context in `palette.md` and user instructions, the goal is to implement ONE micro-UX improvement. A great candidate found in the memory is: "Search input components should implement a clear button ('X' icon) that appears when text is entered to allow users to quickly reset the query."
+
+2. **Locate the Target**: The search input in `components/session-list.tsx` currently lacks a clear button.
+
+3. **Plan the Change**:
+   - Update `components/session-list.tsx` to import the `X` icon from `lucide-react`.
+   - Modify the search input container to include a clear button when `searchQuery` is not empty.
+   - The button should clear `searchQuery` when clicked and have appropriate `aria-label` for accessibility.
+   - The decorative `Search` icon should have `pointer-events-none` to prevent interference, as per memory guidelines.
+   - Ensure the `X` button works with keyboard (is focusable or part of the natural flow).
+
+4. **Implementation details**:
+   - In `components/session-list.tsx`, add `X` to the `lucide-react` import.
+   - Add a `<button>` next to the `<Input>` inside the `.relative` container.
+   - The button should render conditionally if `searchQuery.length > 0`.
+   - The `Search` icon already exists. Let's add `pointer-events-none` to its class name.
+
+5. **Review**:
+   - Add `pointer-events-none` to the Search icon.
+   - Add a small X button to the right of the input to clear search.


### PR DESCRIPTION
🎨 **Palette:** Accessible Search Input Interactions

**💡 What:** 
Added a clear button ('X' icon) to the search input in the Session List that appears only when text is entered. I also improved the empty state logic so that when a search yields zero results, the search bar itself doesn't disappear, allowing the user to easily clear or modify their query.

**🎯 Why:** 
Input fields meant for searching or filtering can be tedious to empty manually by repeatedly pressing backspace. Providing a clear button reduces friction significantly. Additionally, hiding the search bar entirely on a 0-result search makes it frustrating to try another query.

**♿ Accessibility:**
- Added `aria-label="Clear search"` to the new button for screen readers.
- Ensured the button is keyboard accessible and has clear `focus-visible` styles (`ring-2 ring-purple-500/50`).
- Applied `pointer-events-none` to the decorative search icon so it doesn't accidentally intercept user clicks.
- Used `pr-7` on the input to ensure long search queries don't visually overlap with the clear button.

A new journal entry was added to `.jules/palette.md` to record these specific UX learnings.

---
*PR created automatically by Jules for task [14016074718667997829](https://jules.google.com/task/14016074718667997829) started by @sbhavani*