### PR TITLE
🎨 Palette: Add clear button to session search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-03-21 - Filter Input Usability
+
+**Learning:** When a list is filtered to an empty state and the empty state message completely replaces the list container, users lose access to the search input and cannot clear or modify their query.
+**Action:** Empty state UI must be rendered *inside* the scrollable content area, ensuring that sticky headers containing search/filter controls remain accessible.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -153,20 +153,6 @@ export function SessionList({
 
 
 
-  if (visibleSessions.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-6">
-        <p className="text-xs text-muted-foreground text-center leading-relaxed">
-          {searchQuery
-            ? "No sessions match your search."
-            : sessions.length === 0
-              ? "No sessions yet. Create one to get started!"
-              : "All sessions are archived."}
-        </p>
-      </div>
-    );
-  }
-
   const sessionLimit = 100;
   // Calculate usage based on sessions created today, regardless of search/archive status
   const dailySessionCount = sessions.filter((session) => {
@@ -184,19 +170,39 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery("")}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-muted-foreground hover:text-white rounded-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-purple-500/50 transition-colors"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">
           <div className="p-2 space-y-1">
-            {visibleSessions.map((session) => (
+            {visibleSessions.length === 0 ? (
+              <div className="flex items-center justify-center p-6">
+                <p className="text-xs text-muted-foreground text-center leading-relaxed">
+                  {searchQuery
+                    ? "No sessions match your search."
+                    : sessions.length === 0
+                      ? "No sessions yet. Create one to get started!"
+                      : "All sessions are archived."}
+                </p>
+              </div>
+            ) : (
+              visibleSessions.map((session) => (
               <CardSpotlight
                 key={session.id}
                 radius={250}
@@ -249,7 +255,8 @@ export function SessionList({
                   </div>
                 </div>
               </CardSpotlight>
-            ))}
+            ))
+            )}
           </div>
         </ScrollArea>
 


### PR DESCRIPTION
💡 **What:** Added a clear button to the session list search input and fixed an issue where the search bar was hidden when zero results were found.

🎯 **Why:** Previously, searching for a non-existent session triggered an empty state view that completely overwrote the layout. This hid the search input, making it impossible for users to clear their search and see their sessions again. Additionally, clearing a long search query manually is tedious; an explicit clear button is a standard and expected UX pattern.

📸 **Before/After:** Not applicable (functionality/layout fix).

♿ **Accessibility:**
*   Added `pointer-events-none` to the decorative search icon so it does not intercept clicks.
*   Added an `aria-label="Clear search"` to the new clear button.
*   The clear button is keyboard-accessible with proper focus rings (`focus-visible:ring-1`).

---
*PR created automatically by Jules for task [15384936799262554491](https://jules.google.com/task/15384936799262554491) started by @sbhavani*