### PR TITLE
🎨 Palette: Add clear button to search input and fix icon accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-12-22 - Search Input Friction
+
+**Learning:** Search inputs without a quick way to clear text create friction, especially when filtering long lists. Users have to manually backspace or select-all-delete. Additionally, decorative search icons overlapping the input area can unintentionally block clicks if they lack `pointer-events-none`.
+**Action:** Always add a clear button (e.g., 'X' icon) to search inputs that appears when text is entered, and ensure decorative icons over inputs are set to ignore pointer events.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -184,14 +184,24 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                aria-label="Clear search"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-white transition-colors"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">


### PR DESCRIPTION
## 💡 What
Added a clear button ('X') to the search input in the Session List that allows users to easily clear their search query. Also added `pointer-events-none` to the decorative magnifying glass icon to prevent it from blocking mouse events.

## 🎯 Why
Search inputs without a quick way to clear text create friction, forcing users to manually backspace or select-all-delete. Additionally, decorative icons that overlay inputs can unintentionally block clicks if they don't ignore pointer events.

## ♿ Accessibility
- Added `aria-label="Clear search"` to the new clear button.
- Used native `button` with `type="button"`.
- Prevented the search icon from intercepting pointer events.

---
*PR created automatically by Jules for task [14460497034280993059](https://jules.google.com/task/14460497034280993059) started by @sbhavani*