### PR TITLE
🎨 Palette: Improve SessionList search UX and empty state behavior

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2024-05-09 - Persisting Search Context in Empty States
+
+**Learning:** When a search yields no results and triggers an empty state, if the empty state replaces the entire layout (including the search bar), the user is trapped without a way to clear their query or search again.
+**Action:** Empty states triggered by filters or search must render *below* or *alongside* the active filter controls, ensuring the user can always escape the empty state.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -153,20 +153,6 @@ export function SessionList({
 
 
 
-  if (visibleSessions.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-6">
-        <p className="text-xs text-muted-foreground text-center leading-relaxed">
-          {searchQuery
-            ? "No sessions match your search."
-            : sessions.length === 0
-              ? "No sessions yet. Create one to get started!"
-              : "All sessions are archived."}
-        </p>
-      </div>
-    );
-  }
-
   const sessionLimit = 100;
   // Calculate usage based on sessions created today, regardless of search/archive status
   const dailySessionCount = sessions.filter((session) => {
@@ -183,18 +169,39 @@ export function SessionList({
     <TooltipProvider>
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
-          <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+          <div className="relative group">
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 text-muted-foreground hover:text-white focus:outline-none focus:ring-1 focus:ring-purple-500/50 rounded-sm"
+                aria-label="Clear search"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">
+          {visibleSessions.length === 0 ? (
+            <div className="flex items-center justify-center p-6 h-full">
+              <p className="text-xs text-muted-foreground text-center leading-relaxed">
+                {searchQuery
+                  ? "No sessions match your search."
+                  : sessions.length === 0
+                    ? "No sessions yet. Create one to get started!"
+                    : "All sessions are archived."}
+              </p>
+            </div>
+          ) : (
           <div className="p-2 space-y-1">
             {visibleSessions.map((session) => (
               <CardSpotlight
@@ -251,6 +258,7 @@ export function SessionList({
               </CardSpotlight>
             ))}
           </div>
+          )}
         </ScrollArea>
 
         {/* Session Limit Indicator */}


### PR DESCRIPTION
💡 **What:** Added a clear (X) button to the SessionList search bar that appears when there is text, and refactored the "No sessions" empty state so the search bar remains visible and usable even when a search yields no results.

🎯 **Why:** Previously, if a user typed a search query that returned no results, the component executed an early return, completely replacing the view with a "No sessions match your search" message. This removed the search bar entirely, trapping the user without a way to clear their query or search again. Additionally, the new clear button makes resetting the search much faster and more intuitive. 

📸 **Before/After:** The empty state now properly renders inside the `ScrollArea`, keeping the search bar at the top intact.

♿ **Accessibility:** Added an `aria-label="Clear search"` to the new button to ensure screen reader compatibility, and added `pointer-events-none` to the Search icon so it doesn't accidentally intercept user clicks meant for the input field.

---
*PR created automatically by Jules for task [2546658266759794028](https://jules.google.com/task/2546658266759794028) started by @sbhavani*