### PR TITLE
🎨 Palette: Add clear button to search input in session list

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-12-22 - Search Input Clarity
+
+**Learning:** Search inputs without a clear button force users to manually delete their query to see all results again, which is tedious. Additionally, absolute positioned icons over inputs intercept clicks unless configured properly.
+**Action:** Always add a conditionally rendered clear ('X') button to search inputs. Add \`pointer-events-none\` to decorative search icons.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -153,19 +153,6 @@ export function SessionList({
 
 
 
-  if (visibleSessions.length === 0) {
-    return (
-      <div className="flex items-center justify-center p-6">
-        <p className="text-xs text-muted-foreground text-center leading-relaxed">
-          {searchQuery
-            ? "No sessions match your search."
-            : sessions.length === 0
-              ? "No sessions yet. Create one to get started!"
-              : "All sessions are archived."}
-        </p>
-      </div>
-    );
-  }
 
   const sessionLimit = 100;
   // Calculate usage based on sessions created today, regardless of search/archive status
@@ -184,19 +171,42 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+
+            {searchQuery && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setSearchQuery("")}
+                aria-label="Clear search"
+                className="absolute right-1 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground hover:text-white hover:bg-white/10"
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">
-          <div className="p-2 space-y-1">
-            {visibleSessions.map((session) => (
+          {visibleSessions.length === 0 ? (
+            <div className="flex items-center justify-center p-6">
+              <p className="text-xs text-muted-foreground text-center leading-relaxed">
+                {searchQuery
+                  ? "No sessions match your search."
+                  : sessions.length === 0
+                    ? "No sessions yet. Create one to get started!"
+                    : "All sessions are archived."}
+              </p>
+            </div>
+          ) : (
+            <div className="p-2 space-y-1">
+              {visibleSessions.map((session) => (
               <CardSpotlight
                 key={session.id}
                 radius={250}
@@ -250,7 +260,8 @@ export function SessionList({
                 </div>
               </CardSpotlight>
             ))}
-          </div>
+            </div>
+          )}
         </ScrollArea>
 
         {/* Session Limit Indicator */}


### PR DESCRIPTION
## 💡 What

* Added a clear ('X') button to the `Search` input inside `SessionList` that resets `searchQuery` when clicked.
* Added `pointer-events-none` to the absolute positioned search icon to ensure it doesn't intercept clicks inside the input field.
* Repositioned empty state message to always display the search field.

## 🎯 Why

Search inputs without a clear button force users to manually delete their query to see all results again, which is tedious and a poor UX. The `pointer-events-none` class fixes an accessibility bug on absolute positioned icons. We also noticed the empty state logic was unmounting the search input entirely when zero results match the query, making the search bar disappear.

## ♿ Accessibility

* Icon-only button (`X`) is given an `aria-label="Clear search"`.
* Decorative search icon now has `pointer-events-none`.

---
*PR created automatically by Jules for task [7340896376312703342](https://jules.google.com/task/7340896376312703342) started by @sbhavani*