### PR TITLE
🎨 Palette: Add clear search button to session list

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-12-22 - Search Input Friction
+
+**Learning:** Search inputs without an explicit "clear" mechanism require users to manually select and delete text, creating unnecessary interaction friction, especially on mobile devices.
+**Action:** Always include a clear button (typically an 'X' icon) within search inputs that appears when the input contains text.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -184,14 +184,23 @@ export function SessionList({
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
           <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className="h-7 w-full bg-black/50 pl-7 pr-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-white transition-colors flex items-center justify-center h-full px-1"
+                aria-label="Clear search"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">


### PR DESCRIPTION
💡 **What**: Added an 'X' button to the search input in the Session List that appears when text is entered, allowing users to quickly clear their search query. Also made the search icon `pointer-events-none`. Added a related learning to Palette's journal.

🎯 **Why**: Search inputs without a clear mechanism require users to manually select and delete text or spam backspace, which creates interaction friction.

📸 **Before/After**: See PR changes in UI (screenshot attached in original review).
♿ **Accessibility**: Added an `aria-label="Clear search"` to the new button for screen reader support.

---
*PR created automatically by Jules for task [3270714729510159814](https://jules.google.com/task/3270714729510159814) started by @sbhavani*