### PR TITLE
🎨 Palette: Add clearable search and fix icon pointer events

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -44,3 +44,8 @@
 
 **Learning:** While relative dates (e.g., "2 days ago") are cleaner for scanning, users often need the precision of exact timestamps. Tooltips provide the perfect mechanism for this "progressive disclosure"—keeping the interface clean while making detailed data available on demand.
 **Action:** Use relative time for display and exact timestamp in tooltips.
+
+## 2025-12-21 - Clearable Search Inputs and Pointer Events
+
+**Learning:** Search inputs often contain decorative icons (like a magnifying glass) overlaid on the input field. If these icons lack `pointer-events-none`, they block clicks, causing frustration. Additionally, users need a quick way to clear active search queries without repeatedly pressing backspace.
+**Action:** Always add `pointer-events-none` to decorative icons overlaid on inputs. Add a clear button ('X') that appears only when the search input has content.

--- a/components/session-list.tsx
+++ b/components/session-list.tsx
@@ -6,7 +6,7 @@ import type { Session } from "@/types/jules";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Search } from "lucide-react";
+import { Search, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -183,15 +183,24 @@ export function SessionList({
     <TooltipProvider>
       <div className="h-full flex flex-col bg-zinc-950 overflow-hidden">
         <div className="px-3 py-2 border-b border-white/[0.08] shrink-0">
-          <div className="relative">
-            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+          <div className="relative group">
+            <Search className="absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground pointer-events-none" />
             <Input
               placeholder="Search for repo or sessions"
               aria-label="Search sessions"
-              className="h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50"
+              className={`h-7 w-full bg-black/50 pl-7 text-[10px] border-white/10 focus-visible:ring-purple-500/50 placeholder:text-muted-foreground/50 transition-colors ${searchQuery ? 'pr-7' : ''}`}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-purple-500/50 rounded-sm"
+                aria-label="Clear search"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
           </div>
         </div>
         <ScrollArea className="flex-1 min-h-0">


### PR DESCRIPTION
Added a clear ('X') button to the `SessionList` search input that appears when there is text, and added `pointer-events-none` to the decorative search icon. This improves interaction quality by providing a quick way to reset the query and preventing the search icon from intercepting clicks meant for the input field. The clear button is fully accessible with an `aria-label` and focus ring.

---
*PR created automatically by Jules for task [8297414844171041609](https://jules.google.com/task/8297414844171041609) started by @sbhavani*